### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.10](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.6](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.34](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.19](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.19](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.19) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.10](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.34](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: salaboy
-  repo: fmtok8s-c4p
-  url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.19
+  repo: fmtok8s-agenda
+  url: https://github.com/salaboy/fmtok8s-agenda
+  version: 0.0.10
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: salaboy
+  repo: fmtok8s-api-gateway
+  url: https://github.com/salaboy/fmtok8s-api-gateway
+  version: 0.0.34
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: salaboy
-  repo: fmtok8s-agenda
-  url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.10
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10
+  repo: fmtok8s-email
+  url: https://github.com/salaboy/fmtok8s-email
+  version: 0.0.6
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: salaboy
-  repo: fmtok8s-api-gateway
-  url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.34
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34
+  repo: fmtok8s-c4p
+  url: https://github.com/salaboy/fmtok8s-c4p
+  version: 0.0.19
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.19

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.10
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.18

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,8 +7,7 @@ dependencies:
   version: 0.0.18
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.31
+  version: 0.0.34
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.5
-

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.10
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.18
+  version: 0.0.19
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.34

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.34
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.5](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.5) to [0.0.6](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.6 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.8](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.8) to [0.0.10](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.10 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) to [0.0.19](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.19)

Command run was `jx step create pr chart --name fmtok8s-api-c4p --version 0.0.19 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.31](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.31) to [0.0.34](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.34 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`