### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-agenda from 0.0.10 to 0.0.11

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,3 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.6](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.20](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.20) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.11](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.11) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -11,3 +11,9 @@ dependencies:
   url: https://github.com/salaboy/fmtok8s-c4p
   version: 0.0.20
   versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.20
+- host: github.com
+  owner: salaboy
+  repo: fmtok8s-agenda
+  url: https://github.com/salaboy/fmtok8s-agenda
+  version: 0.0.11
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.11

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.19


### PR DESCRIPTION
Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.10](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.10) to [0.0.11](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.11)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.11 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`