### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-email from 0.0.6 to 0.0.8

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.6](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.20](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.20) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.11](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.11) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.6
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6
+  version: 0.0.8
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.34
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.6
+  version: 0.0.8


### PR DESCRIPTION
Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.6](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.6) to [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.8 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`