### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-c4p to 0.0.25

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.24](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.24) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.11](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.11) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.24
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.24
+  version: 0.0.25
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda


### PR DESCRIPTION
Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) to [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25)

Command run was `jx step create pr chart --name fmtok8s-api-c4p --version 0.0.25 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`