### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.26](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.26) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.12](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.12) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.26](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.26) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.12](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.12) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.25
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25
+  version: 0.0.26
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.26
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.8
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8
+  version: 0.0.9
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.12
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.12
+  version: 0.0.13
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.12
+  version: 0.0.13
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.12
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.25
+  version: 0.0.26
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.34

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.34
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7


### PR DESCRIPTION
Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) to [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.9 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.12](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.12) to [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.13 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) to [0.0.26](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.26)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.26 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`