### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-api-gateway from 0.0.34 to 0.0.35

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,3 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.35](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.35) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -17,3 +17,9 @@ dependencies:
   url: https://github.com/salaboy/fmtok8s-agenda
   version: 0.0.13
   versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13
+- host: github.com
+  owner: salaboy
+  repo: fmtok8s-api-gateway
+  url: https://github.com/salaboy/fmtok8s-api-gateway
+  version: 0.0.35
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.35

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.27
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.34
+  version: 0.0.35
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.34](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.34) to [0.0.35](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.35)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.35 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`