### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.84](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.84) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.41](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.33](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.40](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.40) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.41](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.41) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.85](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.85) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.26](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.26) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.27](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.36](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.43](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.77](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.77) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.78](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.78) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.70](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.70) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.71](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.71) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.23](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.47](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.47) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.59](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.90](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.90) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.92](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.92) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.22](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.35](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.35) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.46](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.46) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.79](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.79) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.80](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.80) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.40](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.40) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.28](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.15](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.42](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.42) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.20](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.12](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.39](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.16](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.49](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.73](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.39](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.39) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.66](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.66) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.10](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.38](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.27](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.60](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.61](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.61) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.28](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.28) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.11](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.49](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.75](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.75) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.40](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.97](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.97) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.98](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.98) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.33](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.40](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.40) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.22](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.58](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.89](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.89) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.90](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.90) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.87](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.87) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.88](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.88) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.93](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.93) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.95](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.95) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.21](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.21) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.22](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.22) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.88](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.88) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.89](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.89) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.71](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.71) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.72](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.72) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.50](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.50) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.80](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.80) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.83](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.83) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.49](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.73](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.75](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.75) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.11](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.15](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.15) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.29](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.29) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.30](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.30) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.58](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.28](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.28) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.29](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.69](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.69) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.70](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.70) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.16](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.20](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.36](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.27](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.61](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.61) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.62](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.12](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.13](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.16](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.35](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.35) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.15](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.15](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.42](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.42) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.46](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.46) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.36](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.13](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.16](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.33](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.25](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.25) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.26](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.26) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.19](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.19) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.35](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.35) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.23](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.36](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.72](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.72) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.73](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.15](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.16](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.20](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.25](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.37](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.60](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.26](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.62](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.65](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.22](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.58](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.35](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.35) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.95](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.95) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.97](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.97) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.40](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.76](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.76) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.23](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.36](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.59](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.29](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.29) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.31](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.31](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.39](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.85](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.85) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.86](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.86) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.66](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.66) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.67](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.67) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.67](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.67) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.68](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.68) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.38](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.38) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.39](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.39) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.31](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.32](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.32) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.39](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.33](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.41](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.19](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.19) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.11](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.15](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.15) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.37](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.44](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.21](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.21) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.47](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.47) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.24](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.59](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.27](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.40](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.40) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.83](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.83) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.84](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.84) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.10](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.38](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.14](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.14) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.25](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.27](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.60](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.86](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.86) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.87](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.87) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.32](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.32) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.12](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.39](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.78](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.78) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.79](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.79) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.37](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.37) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.27](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.26](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.62](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.68](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.68) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.69](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.69) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.92](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.92) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.93](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.93) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.41](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.50](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.50) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.26](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.48](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.48) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.65](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.10](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.14](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.14) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.28](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.28) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.37](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.37) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.38](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.38](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.38) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.39](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.39) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.48](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.48) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.65](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.38](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.38) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.22](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.22) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.38](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.38) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.40](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.76](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.76) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.77](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.77) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.37](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.43](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.44](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.39](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.39) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.25](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.36](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.37](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.43](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.29](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.29) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.30](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.30) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.24](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.25](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.37](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.24](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.59](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.37](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.38
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.38
+  version: 0.0.39
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.39
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.97
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.97
+  version: 0.0.98
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.98

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.16
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16
+  version: 0.0.22
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.39
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.39
+  version: 0.0.40
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.73
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73
+  version: 0.0.75
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.75

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.69
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.69
+  version: 0.0.70
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.70

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.33
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33
+  version: 0.0.35
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.35
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.58
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58
+  version: 0.0.59
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.27
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27
+  version: 0.0.26
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.32
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.32
+  version: 0.0.33
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.31
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31
+  version: 0.0.32
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.32
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.66
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.66
+  version: 0.0.67
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.67

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.30
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.30
+  version: 0.0.35
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.35
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.26
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.26
+  version: 0.0.27
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.27
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.47
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.47
+  version: 0.0.48
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.48
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.85
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.85
+  version: 0.0.86
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.86

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.28
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.28
+  version: 0.0.29
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.29
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.22
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22
+  version: 0.0.23
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.38
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38
+  version: 0.0.39
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.43
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43
+  version: 0.0.44
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.76
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.76
+  version: 0.0.77
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.77

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.28
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.28
+  version: 0.0.29
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.29
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.70
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.70
+  version: 0.0.71
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.71

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.89
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.89
+  version: 0.0.90
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.90

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.28
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28
+  version: 0.0.29
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.36
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36
+  version: 0.0.37
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.88
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.88
+  version: 0.0.89
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.89

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.72
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.72
+  version: 0.0.73
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.10
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10
+  version: 0.0.11
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.59
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59
+  version: 0.0.60
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.15
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.15
+  version: 0.0.16
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.37
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.37
+  version: 0.0.38
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.12
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12
+  version: 0.0.13
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.13
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.62
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62
+  version: 0.0.65
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.35
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.35
+  version: 0.0.36
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.71
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.71
+  version: 0.0.72
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.72

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.22
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.22
+  version: 0.0.25
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.25
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.27
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.27
+  version: 0.0.28
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.28
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.79
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.79
+  version: 0.0.80
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.80

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.49
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49
+  version: 0.0.50
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.50
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.46
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.46
+  version: 0.0.47
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.47
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.35
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.35
+  version: 0.0.36
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.87
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.87
+  version: 0.0.88
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.88

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.37
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37
+  version: 0.0.38
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.38
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.16
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16
+  version: 0.0.19
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.19
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.90
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.90
+  version: 0.0.92
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.92

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.13
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13
+  version: 0.0.14
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.14
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.39
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39
+  version: 0.0.40
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.40

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.21
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.21
+  version: 0.0.22
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.22
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.37
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37
+  version: 0.0.38
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.38
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.38
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.38
+  version: 0.0.39
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.39
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.83
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.83
+  version: 0.0.84
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.84

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.36
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36
+  version: 0.0.37
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.37

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.27
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27
+  version: 0.0.28
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.28
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.61
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.61
+  version: 0.0.62
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.20
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20
+  version: 0.0.21
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.21
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.67
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.67
+  version: 0.0.68
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.68

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.78
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.78
+  version: 0.0.79
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.79

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.26
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26
+  version: 0.0.28
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.29
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.29
+  version: 0.0.31
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.24
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24
+  version: 0.0.25
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.15
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15
+  version: 0.0.16
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.36
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36
+  version: 0.0.37
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.40
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.40
+  version: 0.0.41
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.41

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.92
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.92
+  version: 0.0.93
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.93

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.9
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9
+  version: 0.0.10
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.86
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.86
+  version: 0.0.87
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.87

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.77
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.77
+  version: 0.0.78
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.78

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.41
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.41
+  version: 0.0.42
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.42

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.75
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.75
+  version: 0.0.76
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.76

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.25
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.25
+  version: 0.0.26
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.26
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.25
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25
+  version: 0.0.27
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.84
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.84
+  version: 0.0.85
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.85

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.95
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.95
+  version: 0.0.97
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.97

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.80
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.80
+  version: 0.0.83
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.83

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.11
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11
+  version: 0.0.12
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.44
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44
+  version: 0.0.58
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.93
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.93
+  version: 0.0.95
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.95

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.39
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.39
+  version: 0.0.40
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.40
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.68
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.68
+  version: 0.0.69
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.69

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.19
+  version: 0.0.20
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.40
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40
+  version: 0.0.41
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.41
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.23
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23
+  version: 0.0.24
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.65
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65
+  version: 0.0.66
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.66

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.48
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.48
+  version: 0.0.49
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.14
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.14
+  version: 0.0.15
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.15
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.13
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.13
+  version: 0.0.15
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.42
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.42
+  version: 0.0.43
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.40
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.40
+  version: 0.0.46
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.46
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.29
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.29
+  version: 0.0.30
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.30
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.60
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60
+  version: 0.0.61
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.61

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.39
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.11
+  version: 0.0.12
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.58
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.16
+  version: 0.0.22
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.62
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.26
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.46
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.58
+  version: 0.0.59
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.23

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.47
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.59
+  version: 0.0.60
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.25

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.14
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.28
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.27
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.37
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.97
+  version: 0.0.98
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.68
+  version: 0.0.69
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.84
+  version: 0.0.85
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.19
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.33
+  version: 0.0.35
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.41

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.89
+  version: 0.0.90
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.38
+  version: 0.0.39
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.48

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.27
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.39
+  version: 0.0.40
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.44

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.33
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.39
+  version: 0.0.40
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.13

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.67
+  version: 0.0.68
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.38
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.10
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.16
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.32
+  version: 0.0.33
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.39

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.83
+  version: 0.0.84
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.42
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.28
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.40

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.37
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.47
+  version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.65

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.84
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.28
+  version: 0.0.29
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.15
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.28
+  version: 0.0.29
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.78
+  version: 0.0.79
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.15
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.31
+  version: 0.0.32
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.39

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.35
+  version: 0.0.36
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.46

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.25
+  version: 0.0.26
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.39

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.39
+  version: 0.0.40
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.49

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.73
+  version: 0.0.75
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.95
+  version: 0.0.97
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.20
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.37
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.43

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.86
+  version: 0.0.87
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.35
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.40
+  version: 0.0.46
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.58

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.60
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.25
+  version: 0.0.27
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.31
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.38
+  version: 0.0.39
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.11

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.87
+  version: 0.0.88
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.36
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.42
+  version: 0.0.43
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.16

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.66
+  version: 0.0.67
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.41
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.49
+  version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.84

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.90
+  version: 0.0.92
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.32

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.30
+  version: 0.0.35
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.40

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.37
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.47

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.69
+  version: 0.0.70
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.47
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.60
+  version: 0.0.61
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.27

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.15
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.29
+  version: 0.0.31
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.37
+  version: 0.0.38
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.48

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.39
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.48
+  version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.73

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.22
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.38
+  version: 0.0.39
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.44

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.75
+  version: 0.0.76
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.71
+  version: 0.0.72
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.41
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.15
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.70
+  version: 0.0.71
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.59
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.24
+  version: 0.0.25
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.85
+  version: 0.0.86
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.36
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.46
+  version: 0.0.47
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.59

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.22
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.37
+  version: 0.0.38
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.44

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.35
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.41
+  version: 0.0.42
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.15

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.14
+  version: 0.0.15
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.22
+  version: 0.0.25
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.39

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.28
+  version: 0.0.29
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.40

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.47
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.61
+  version: 0.0.62
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.27

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.29
+  version: 0.0.30
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.40

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.20
+  version: 0.0.21
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.37

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.58
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.22
+  version: 0.0.23
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.21
+  version: 0.0.22
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.37

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.20
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.35
+  version: 0.0.36
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.42

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.33
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.40
+  version: 0.0.41
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.13

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.65
+  version: 0.0.66
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.93
+  version: 0.0.95
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.40
+  version: 0.0.41
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.49

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.79
+  version: 0.0.80
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.14
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.27

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.88
+  version: 0.0.89
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.38
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.50
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.92
+  version: 0.0.93
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.47
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.62
+  version: 0.0.65
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.20
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.35

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.40
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.44
+  version: 0.0.58
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.16

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.26
+  version: 0.0.27
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.39

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.59
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.23
+  version: 0.0.24
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.16
+  version: 0.0.19
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.33

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.37
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.43
+  version: 0.0.44
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.16

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.48
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.72
+  version: 0.0.73
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.80
+  version: 0.0.83
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.27
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.37
+  version: 0.0.38
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.39
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.12
+  version: 0.0.13
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.75
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.26
+  version: 0.0.28
 - name: fmtok8s-tests
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.76
+  version: 0.0.77
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28

--- a/kubecon-app/requirements.yaml
+++ b/kubecon-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.49
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.77
+  version: 0.0.78
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.28


### PR DESCRIPTION
Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.98](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.98)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.98 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.97](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.97)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.97 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.95](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.95)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.95 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.93](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.93)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.93 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.92](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.92)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.92 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.90](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.90)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.90 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.89](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.89)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.89 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.88](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.88)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.88 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.87](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.87)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.87 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.86](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.86)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.86 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.85](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.85)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.85 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.29](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.29)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.29 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.50](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.50)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.50 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.41](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.41)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.41 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.84](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.84)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.84 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.83](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.83)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.83 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.80](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.80)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.80 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.79](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.79)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.79 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.78](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.78)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.78 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.77](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.77)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.77 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.76](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.76)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.76 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.28](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.28)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.28 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.40](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.40)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.40 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.75](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.75)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.75 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.49](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.49)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.49 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.73](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.73)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.73 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.72](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.72)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.72 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.71](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.71)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.71 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.70](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.70)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.70 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.69](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.69)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.69 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.68](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.68)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.68 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.67](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.67)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.67 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.66](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.66)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.66 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.39](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.39)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.39 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.38](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.38)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.38 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.48](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.48)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.48 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.65](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.65)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.65 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.26](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.26)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.26 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.62](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.62)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.62 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.61](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.61)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.61 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.27](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.27)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.27 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.60](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.60)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.60 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.25](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.25)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.25 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.37](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.37)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.37 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.24](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.24)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.24 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.47](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.47)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.47 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.59](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.59)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.59 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.23](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.23)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.23 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.36](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.36)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.36 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.46](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.46)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.46 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.35](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.35)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.35 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.22](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.22)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.22 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.58](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.58)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.58 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.30](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.30)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.30 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.29](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.29)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.29 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.28](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.28)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.28 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.40](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.40)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.40 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.27](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.27)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.27 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.26](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.26)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.26 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.25](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.25)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.25 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.39](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.39)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.39 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.38](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.38)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.38 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.22](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.22)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.22 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.21](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.21)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.21 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.44](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.44 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.37](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.37)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.37 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.43](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.43)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.43 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.36](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.36)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.36 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.16](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.16 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.20](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.20)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.20 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.42](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.42)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.42 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.15](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.15)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.15 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.35](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.35)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.35 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.19](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.19)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.19 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.41](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.41)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.41 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.40](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.40)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.40 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.33](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.33)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.33 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.13](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.13)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.13 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.16](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.16)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.16 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.12](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.12)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.12 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.32](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.32)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.32 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.39](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.39)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.39 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.31](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.31)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.31 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.29](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.29)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.29 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.15](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.15)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.15 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.11](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.11)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.11 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.28](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.28)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.28 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.14](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.14)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.14 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.10](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.10)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.10 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.38](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.38)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.38 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.37](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.37)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.37 --repo https://github.com/salaboy/fmtok8s-kubecon-app.git`